### PR TITLE
Update iri-installer to latest IRI version

### DIFF
--- a/dist/installer/iri-installer.js
+++ b/dist/installer/iri-installer.js
@@ -16,7 +16,7 @@ var _require2 = require('./base-package-installer'),
 
 var DEFAULT_OPTIONS = {
     name: 'iri',
-    latestVersion: '1.4.2.2',
+    latestVersion: '1.4.2.4',
     emulateWindows: false,
     repo: {
         owner: 'iotaledger',

--- a/src/installer/iri-installer.js
+++ b/src/installer/iri-installer.js
@@ -3,7 +3,7 @@ const { BasePackageInstaller } = require('./base-package-installer');
 
 const DEFAULT_OPTIONS = {
     name: 'iri',
-    latestVersion: '1.4.2.2',
+    latestVersion: '1.4.2.4',
     emulateWindows: false,
     repo: {
         owner: 'iotaledger',


### PR DESCRIPTION
## What does this PR fixes?

When running Bolero, IRI throws an error: `error: could not find version 1.4.2.2 in latest!`

## What does it do?

IRI version has been changed in iri-installer

## How to test this PR?

### You can get the linux/windows builds of bolero.fun here
https://github.com/AcelisWeaven/bolero.lib/releases/tag/0.3.3.1

### Or you can make the builds yourself

Clone bolero.fun and use this PR's branch to package the app again.

```
git clone https://github.com/SemkoDev/bolero.fun.git
cd bolero.fun
npm install
npm install bolero.lib@AcelisWeaven/bolero.lib.git#fix/update-iri-version --save
npm run build
npm run package
```